### PR TITLE
Only deploy master

### DIFF
--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -6,9 +6,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
       
 # Authenticate to the the server via ssh 
 # and run our deployment script 


### PR DESCRIPTION
Wenn das Script deploy.sh das macht was sein Name impliziert darf dieses Script nur bei Pushes auf master ausgeführt werden - sofern der master IMMER sauber ist.

Ggf. muss diese Action aus den PR regeln raus damit die PRs grün angezeigt werden.