### PR TITLE
Fix intermediate container PHP version

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ docker run --rm \
     -u "$(id -u):$(id -g)" \
     -v $(pwd):/var/www/html \
     -w /var/www/html \
-    laravelsail/php80-composer:latest \
+    laravelsail/php81-composer:latest \
     composer install --ignore-platform-reqs
 ```
 


### PR DESCRIPTION
copy and paste mistake, intermediate container should use >=php8.1 as stated in the requirements